### PR TITLE
Fix auth and token weirdness

### DIFF
--- a/App/main.py
+++ b/App/main.py
@@ -1,6 +1,8 @@
 import os
 from flask import Flask, flash, render_template
 from flask_uploads import DOCUMENTS, IMAGES, TEXT, UploadSet, configure_uploads
+from flask_jwt_extended import get_jwt, create_access_token, set_access_cookies, current_user
+from datetime import datetime, timezone, timedelta
 from flask_cors import CORS
 from werkzeug.utils import secure_filename
 from werkzeug.datastructures import  FileStorage
@@ -23,6 +25,18 @@ def add_views(app):
 
 def create_app(overrides={}):
     app = Flask(__name__, static_url_path='/static')
+    @app.after_request
+    def refresh_expiring_jwts(response):
+        try:
+            exp_timestamp = get_jwt()["exp"]
+            now = datetime.now(timezone.utc)
+            target_timestamp = datetime.timestamp(now + timedelta(minutes=5))
+            if target_timestamp > exp_timestamp:
+                access_token = create_access_token(identity=current_user.username)
+                set_access_cookies(response, access_token)
+            return response
+        except (RuntimeError, KeyError):
+            return response
     load_config(app, overrides)
     CORS(app)
     add_auth_context(app)

--- a/App/main.py
+++ b/App/main.py
@@ -1,5 +1,5 @@
 import os
-from flask import Flask, render_template
+from flask import Flask, flash, render_template
 from flask_uploads import DOCUMENTS, IMAGES, TEXT, UploadSet, configure_uploads
 from flask_cors import CORS
 from werkzeug.utils import secure_filename
@@ -35,6 +35,7 @@ def create_app(overrides={}):
     @jwt.invalid_token_loader
     @jwt.unauthorized_loader
     def custom_unauthorized_response(error):
-        return render_template('401.html', error=error), 401
+        flash("Must be logged in", "error")
+        return render_template("login.html"), 401
     app.app_context().push()
     return app

--- a/App/views/auth.py
+++ b/App/views/auth.py
@@ -35,6 +35,7 @@ def login_action():
     token = login(data['username'], data['password'])
     if not token:
         flash('Bad username or password given'), 401
+        response = redirect(url_for('auth_views.login_page'))
     else:
         flash('Login Successful')
         response = redirect(url_for('index_views.home_page'))

--- a/App/views/index.py
+++ b/App/views/index.py
@@ -1,16 +1,15 @@
 from flask import Blueprint, redirect, render_template, jsonify, url_for, request
-from App.controllers import initialize
+from App.controllers import initialize, jwt_ignore_expired
 from App.controllers.recipe import get_user_recipes, search_user_recipes
 from App.controllers.ingredient import get_recipe_ingredients
-from flask_jwt_extended import jwt_required, get_jwt, current_user as jwt_current_user
-from datetime import datetime, timezone
+from flask_jwt_extended import jwt_required, current_user as jwt_current_user
 
 index_views = Blueprint('index_views', __name__, template_folder='../templates')
 
 @index_views.route('/', methods=['GET'])
-@jwt_required(optional=True)
+@jwt_ignore_expired()
 def index_page():
-    if jwt_current_user and get_jwt()['exp'] > datetime.timestamp(datetime.now(timezone.utc)):
+    if jwt_current_user:
         return redirect(url_for('index_views.home_page'))
     return redirect(url_for('auth_views.login_page'))
 

--- a/App/views/user.py
+++ b/App/views/user.py
@@ -7,7 +7,6 @@ from App.controllers import (
     create_user,
     get_all_users,
     get_all_users_json,
-    jwt_required
 )
 
 user_views = Blueprint('user_views', __name__, template_folder='../templates')


### PR DESCRIPTION
A collection of fixes to hopefully improve how tokens are handled.
Made a whole custom decorator to handle the one endpoint that needs it (`/` so it can redirect to `/home` if logged in and `/login` if not logged in). `jwt_required` raises an error when tokens are expired, so having that be the decorator for the route meant that once the token expired it wouldn't even be possible to access the route. Created `jwt_ignore_expired` which redirects to the login if the token is invalid (e.g. it's missing because you logged out), and flashes that it's expired when it's expired. Point being, it doesn't throw an error for expired, so the route still works after it expires.

..._then I added a callback after every request to refresh tokens that are about to expire_ (those that will expire within 5 minutes), sooo the custom decorator should not ever _actually_ do anything special in normal use, but it's there if someone goes afk I guess..

Other small changes here and there, but you can just look at the commits for those